### PR TITLE
Auth_UsePolicy

### DIFF
--- a/app/Http/Controllers/QuestionsController.php
+++ b/app/Http/Controllers/QuestionsController.php
@@ -8,6 +8,10 @@ use App\Http\Requests\AskQuestionRequest;
 
 class QuestionsController extends Controller
 {
+    public function __construct() {
+        $this->middleware('auth', ['except' => ['index', 'show']]);
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -66,6 +70,7 @@ class QuestionsController extends Controller
      */
     public function edit(Question $question)
     {
+        $this->authorize("update", $question);
         return view("questions.edit", compact('question'));
     }
 
@@ -78,6 +83,8 @@ class QuestionsController extends Controller
      */
     public function update(AskQuestionRequest $request, Question $question)
     {
+        $this->authorize("update", $question);
+
         $question->update($request->only('title', 'body'));
 
         return redirect('/questions')->with('success', "あなたの質問は更新されました");
@@ -91,6 +98,8 @@ class QuestionsController extends Controller
      */
     public function destroy(Question $question)
     {
+        $this->authorize("delete", $question);
+
         $question->delete();
 
         return redirect('/questions')->with('success', "質問を削除しました");

--- a/app/Policies/QuestionPolicy.php
+++ b/app/Policies/QuestionPolicy.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Question;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class QuestionPolicy
+{
+    use HandlesAuthorization;
+    
+    /**
+     * Determine whether the user can view any questions.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the question.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function update(User $user, Question $question)
+    {
+        return $user->id === $question->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the question.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function delete(User $user, Question $question)
+    {
+        return $user->id === $question->user_id && $question->answers < 1;
+    }
+
+    /**
+     * Determine whether the user can restore the question.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function restore(User $user, Question $question)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the question.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Question  $question
+     * @return mixed
+     */
+    public function forceDelete(User $user, Question $question)
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Question;
+use App\Policies\QuestionPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Model' => 'App\Policies\ModelPolicy',
+        Question::class => QuestionPolicy::class,
     ];
 
     /**

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -35,12 +35,16 @@
                                 <div class="d-flex align-items-center">
                                     <h3 class="mt-0"><a href="{{ $question->url }}">{{ $question->title }}</a></h3>
                                     <div class="ml-auto">
-                                        <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
-                                        <form class="form-delete" method="post" action="{{ route('questions.destroy', $question->id) }}">
-                                            @method('DELETE')
-                                            @csrf
-                                            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">Delete</button>
-                                        </form>
+                                        @can ('update', $question)
+                                            <a href="{{ route('questions.edit', $question->id) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                        @endcan
+                                        @can ('delete', $question)
+                                            <form class="form-delete" method="post" action="{{ route('questions.destroy', $question->id) }}">
+                                                @method('DELETE')
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">Delete</button>
+                                            </form>
+                                        @endcan
                                     </div>
                                 </div>
                                 <p class="lead">


### PR DESCRIPTION
# What
ポリシー機能を用いて質問とupdateとdestroyをそれを投稿したユーザー以外が行えなくする

# Why
・php artisan make:policy QuestionPoricy --model=Questionコマンドで、ポリシーファイルを作成
・ポリシーファイルはほぼ「ユーザーID＝質問のユーザーID」の記述のみでOK。deleteの場合、アンサーが付いている場合消せないように設定
・index.bladeは@canを用いて記述を減らした。
　@if (Auth::user()->can('update', $question))
　　　　↓
　@can ('update', $question)