### PR TITLE
questions#show_add_answers

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -30,4 +30,9 @@ class Answer extends Model
             $answer->question->save();
         });
     }
+
+    public function getCreatedDateAttribute()
+    {
+        return $this->created_at->diffForHumans();
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -25,7 +25,7 @@ class RouteServiceProvider extends ServiceProvider
     public function boot()
     {
         Route::bind('slug', function($slug) {
-            return Question::where('slug', $slug)->first() ?? abort(404);
+            return Question::with('answers.user')->where('slug', $slug)->first() ?? abort(404);
         });
 
         parent::boot();

--- a/app/User.php
+++ b/app/User.php
@@ -52,4 +52,11 @@ class User extends Authenticatable
     {
         return $this->hasMany(Answer::class);
     }
+
+    public function getAvatarAttribute()
+    {
+        $email = $this->email;
+        $size = 32;
+        return "https://www.gravatar.com/avatar/" . md5( strtolower( trim( $email ) ) ) . "?s=" . $size;
+    }
 }

--- a/resources/views/questions/show.blade.php
+++ b/resources/views/questions/show.blade.php
@@ -17,6 +17,48 @@
 
                 <div class="card-body">
                     {!! $question->body_html !!}
+                    <div class="float-right">
+                        <span class="text-muted">Questioned {{ $question->created_date }}</span>
+                        <div class="media mt-2">
+                            <a href="{{ $question->user->url }}" class="pr-2">
+                                <img src="{{ $question->user->avatar }}">
+                            </a>
+                            <div class="media-body mt-1">
+                                <a href="{{ $question->user->url }}">{{ $question->user->name }}</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row mt-4">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                  <div class="card-title">
+                      <h2>{{ $question->answers_count . " " . str_plural('Answer', $question->answers_count) }}</h2>
+                  </div>
+                  <hr>
+                  @foreach ($question->answers as $answer)
+                      <div class="media">
+                          <div class="media-body">
+                              {!! $answer->body_html !!}
+                              <div class="float-right">
+                                  <span class="text-muted">Answered {{ $answer->created_date }}</span>
+                                  <div class="media mt-2">
+                                      <a href="{{ $answer->user->url }}" class="pr-2">
+                                          <img src="{{ $answer->user->avatar }}">
+                                      </a>
+                                      <div class="media-body mt-1">
+                                          <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                      <hr>
+                  @endforeach
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# What
質問の返答を正しく表示されるようにした。

# Why
・questions#showのビューに質問の内容を表示できるよう記述
・返答の投稿時間と返答者の名前、アイコンが表示されるようにした
・アイコンはWardPressのGravatarで用意されているPHP用のコードサンプルを使用した
→https://ja.gravatar.com/site/implement/
・返答者のユーザー情報を得る際のクエリのn+1問題を避けるべく、RouteServiceProviderのbootにて、
with('answers.user')の記述を追加