### PR TITLE
add_answers#update

### DIFF
--- a/app/Http/Controllers/AnswersController.php
+++ b/app/Http/Controllers/AnswersController.php
@@ -29,9 +29,11 @@ class AnswersController extends Controller
      * @param  \App\Answer  $answer
      * @return \Illuminate\Http\Response
      */
-    public function edit(Answer $answer)
+    public function edit(Question $question, Answer $answer)
     {
-        //
+        $this->authorize('update', $answer);
+
+        return view('answers.edit', compact('question', 'answer'));
     }
 
     /**
@@ -41,9 +43,15 @@ class AnswersController extends Controller
      * @param  \App\Answer  $answer
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Answer $answer)
+    public function update(Request $request, Question $question, Answer $answer)
     {
-        //
+        $this->authorize('update', $answer);
+
+        $answer->update($request->validate([
+            'body' => 'required',
+        ]));
+
+        return redirect()->route('questions.show', $question->slug)->with('success', '回答が更新されました');
     }
 
     /**

--- a/app/Policies/AnswerPolicy.php
+++ b/app/Policies/AnswerPolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Answer;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AnswerPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the answer.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function update(User $user, Answer $answer)
+    {
+        return $user->id === $answer->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the answer.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function delete(User $user, Answer $answer)
+    {
+        return $user->id === $answer->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the answer.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function restore(User $user, Answer $answer)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the answer.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Answer  $answer
+     * @return mixed
+     */
+    public function forceDelete(User $user, Answer $answer)
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use App\Question;
 use App\Policies\QuestionPolicy;
+use App\Answer;
+use App\policies\AnswerPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Question::class => QuestionPolicy::class,
+        Answer::class => AnswerPolicy::class,
     ];
 
     /**

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -2,44 +2,61 @@
     <div class="col-md-12">
         <div class="card">
             <div class="card-body">
-              <div class="card-title">
-                  <h2>{{ $answersCount . " " . str_plural('Answer', $answersCount) }}</h2>
-              </div>
-              <hr>
-              @include('layouts._messages')
+                <div class="card-title">
+                    <h2>{{ $answersCount . " " . str_plural('Answer', $answersCount) }}</h2>
+                </div>
+                <hr>
+                @include('layouts._messages')
 
-              @foreach ($answers as $answer)
-                  <div class="media">
-                      <div class="d-fex flex-column vote-controls">
-                          <a title="よい返答です" class="vote-up">
-                              <i class="fas fa-caret-up fa-3x"></i>
-                          </a>
-                          <span class="votes-count">1230</span>
-                          <a title="よくない返答です" class="vote-down off">
-                              <i class="fas fa-caret-down fa-3x"></i>
-                          </a>
-                          <a title="ベストアンサーをつけます" class="vote-accepted mt-2">
-                              <i class="fas fa-check fa-2x"></i>
-                          </a>
-                      </div>
-                      <div class="media-body">
-                          {!! $answer->body_html !!}
-                          <div class="float-right">
-                              <span class="text-muted">Answered {{ $answer->created_date }}</span>
-                              <div class="media mt-2">
-                                  <a href="{{ $answer->user->url }}" class="pr-2">
-                                      <img src="{{ $answer->user->avatar }}">
-                                  </a>
-                                  <div class="media-body mt-1">
-                                      <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
-                                  </div>
-                              </div>
-                          </div>
-                      </div>
-                  </div>
-                  <hr>
-              @endforeach
+                @foreach ($answers as $answer)
+                    <div class="media">
+                        <div class="d-fex flex-column vote-controls">
+                            <a title="よい返答です" class="vote-up">
+                                <i class="fas fa-caret-up fa-3x"></i>
+                            </a>
+                            <span class="votes-count">1230</span>
+                            <a title="よくない返答です" class="vote-down off">
+                                <i class="fas fa-caret-down fa-3x"></i>
+                            </a>
+                            <a title="ベストアンサーをつけます" class="vote-accepted mt-2">
+                                <i class="fas fa-check fa-2x"></i>
+                            </a>
+                        </div>
+                        <div class="media-body">
+                            {!! $answer->body_html !!}
+                            <div class="row">
+                                <div class="col-4">
+                                    <div class="ml-auto">
+                                          @can ('update', $answer)
+                                              <a href="{{ route('questions.answers.edit', [$question->id, $answer->id]) }}" class="btn btn-sm btn-outline-info">Edit</a>
+                                          @endcan
+                                          @can ('delete', $answer)
+                                              <form class="form-delete" method="post" action="{{ route('questions.answers.destroy', [$question->id, $answer->id]) }}">
+                                                  @method('DELETE')
+                                                  @csrf
+                                                  <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">Delete</button>
+                                              </form>
+                                          @endcan
+                                      </div>
+                                </div>
+                                <div class="col-4"></div>
+                                <div class="col-4">
+                                <span class="text-muted">Answered {{ $answer->created_date }}</span>
+                                    <div class="media mt-2">
+                                        <a href="{{ $answer->user->url }}" class="pr-2">
+                                            <img src="{{ $answer->user->avatar }}">
+                                        </a>
+                                        <div class="media-body mt-1">
+                                            <a href="{{ $answer->user->url }}">{{ $answer->user->name }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <hr>
+                @endforeach
             </div>
-        </div>
-    </div>
-</div>
+        </div>  
+    </div>  
+</div>  

--- a/resources/views/answers/edit.blade.php
+++ b/resources/views/answers/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row mt-4">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                  <div class="card-title">
+                      <h1>Editing answer for question: <strong>{{ $question->title }}</strong></h1>
+                  </div>
+                  <hr>
+                  <form action="{{ route('questions.answers.update', [$question->id, $answer->id]) }}" method="post">
+                      @csrf
+                      @method('PATCH')
+                      <div class="form-group">
+                          <textarea class="form-control {{ $errors->has('body') ? 'is-invalid' : '' }}" rows="7" name="body">{{ old('body', $answer->body) }}</textarea>
+                          @if ($errors->has('body'))
+                              <div class="invalid-feedback">
+                                  <strong>{{ $errors->first('body') }}</strong>
+                              </div>
+                          @endif
+                      </div>
+                      <div class="form-group">
+                          <button type="submit" class="btn btn-lg btn-outline-primary">Update</button>
+                      </div>
+                  </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
# What
answers#updateの実装

# Why
・answers/_index.blade.phpにて、回答にeditボタンとdeleteボタンの実装した
→ほぼquestions/indexの使い回し。コピペ活用
・AnswerPolicy.phpを作成し、中身を記述した
→php artisan make:policy AnswerPolicy --model=Answerコマンドでポリシーファイルを作成
　→不要なメソッド項目を削除し、updateとdeleteに現行ユーザーidが回答したユーザーと一致する旨の条件を記述
・AuthServiceProvider.phpにて、Answerモデル及びAnswerPolicyをuseする記述を追加↓
・answers/_index.blade.phpにて、ポリシーを正常に使えるように記述を変更
→ルーティングがquestionsにネストされているので、$answer->idが欲しいなら$question->idも一緒に取得する。[$question->id, $answer->id]
・answers#editのビューを作成
→ほぼ_createのフォームを使い回し。コピペ活用。メソッドにPATCHを指定し、storeをupdateに書き換えた。必要な箇所の文言文字列を変更