### PR TITLE
answers#destroy_at_best_answer_id

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -40,4 +40,9 @@ class Answer extends Model
     {
         return $this->created_at->diffForHumans();
     }
+
+    public function getStatusAttribute()
+    {
+        return $this->id === $this->question->best_answer_id ? 'vote-accepted' : '';
+    }
 }

--- a/database/migrations/2019_09_18_120424_add_foriegn_best_answer_id_to_questions_table.php
+++ b/database/migrations/2019_09_18_120424_add_foriegn_best_answer_id_to_questions_table.php
@@ -17,7 +17,7 @@ class AddForiegnBestAnswerIdToQuestionsTable extends Migration
             $table->foreign('best_answer_id')
                   ->references('id')
                   ->on('answers')
-                  ->onDelete("SET NULL");
+                  ->onDelete('SET NULL');
         });
     }
 

--- a/database/migrations/2019_09_18_120424_add_foriegn_best_answer_id_to_questions_table.php
+++ b/database/migrations/2019_09_18_120424_add_foriegn_best_answer_id_to_questions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddForiegnBestAnswerIdToQuestionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreign('best_answer_id')
+                  ->references('id')
+                  ->on('answers')
+                  ->onDelete("SET NULL");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropForiegn(['best_answer_id']);
+        });
+    }
+}

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -18,7 +18,7 @@
                             <a title="よくない返答です" class="vote-down off">
                                 <i class="fas fa-caret-down fa-3x"></i>
                             </a>
-                            <a title="ベストアンサーをつけます" class="vote-accepted mt-2">
+                            <a title="ベストアンサーをつけます" class="{{ $answer->status }} mt-2">
                                 <i class="fas fa-check fa-2x"></i>
                             </a>
                         </div>


### PR DESCRIPTION
# What
ベストアンサーの回答を削除した際、質問側のベストアンサーidも一緒に消えるように設する

# Why
・AnswerモデルにgetStatusAttributeを設置し、best_answerの回答は見た目が変化するように設定した
・questionsテーブルのbest_answer_idカラムを外部キー参照にし、onDelete('SET NULL')の記述で、消えた時にnullを設置するようにした