### PR TITLE
Add best answer

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -43,6 +43,16 @@ class Answer extends Model
 
     public function getStatusAttribute()
     {
-        return $this->id === $this->question->best_answer_id ? 'vote-accepted' : '';
+        return $this->isBest() ? 'vote-accepted' : '';
+    }
+
+    public function getIsBestAttribute()
+    {
+        return $this->isBest();
+    }
+
+    public function IsBest()
+    {
+        return $this->id === $this->question->best_answer_id;
     }
 }

--- a/app/Http/Controllers/AcceptAnswerController.php
+++ b/app/Http/Controllers/AcceptAnswerController.php
@@ -15,7 +15,10 @@ class AcceptAnswerController extends Controller
      */
     public function __invoke(Answer $answer)
     {
+        $this->authorize('accept', $answer);
+
         $answer->question->acceptBestAnswer($answer);
+        
         return back();
     }
 }

--- a/app/Http/Controllers/AcceptAnswerController.php
+++ b/app/Http/Controllers/AcceptAnswerController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Answer;
+
+class AcceptAnswerController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Answer $answer)
+    {
+        $answer->question->acceptBestAnswer($answer);
+        return back();
+    }
+}

--- a/app/Policies/AnswerPolicy.php
+++ b/app/Policies/AnswerPolicy.php
@@ -22,6 +22,11 @@ class AnswerPolicy
         return $user->id === $answer->user_id;
     }
 
+    public function accept(User $user, Answer $answer)
+    {
+        return $user->id === $answer->question->user_id;
+    }
+
     /**
      * Determine whether the user can delete the answer.
      *

--- a/app/Question.php
+++ b/app/Question.php
@@ -50,4 +50,10 @@ class Question extends Model
         // $question->answers->count()
         // foreach ($question->answers as $answer)
     }
+
+    public function acceptBestAnswer(Answer $answer)
+    {
+        $this->best_answer_id = $answer->id;
+        $this->save();
+    }
 }

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -18,15 +18,28 @@
                             <a title="よくない返答です" class="vote-down off">
                                 <i class="fas fa-caret-down fa-3x"></i>
                             </a>
-                            <a title="ベストアンサーをつけます"
-                                class="{{ $answer->status }} mt-2"
-                                onclick="event.preventDefault(); document.getElementById('accept-answer-{{ $answer->id }}').submit();"
-                                >
-                                <i class="fas fa-check fa-2x"></i>
-                            </a>
-                            <form id="accept-answer-{{ $answer->id }}" action="{{ route('answers.accept', $answer->id) }}" method="POST" style="display:none;">
-                                @csrf
-                            </form>
+                            @can ('accept', $answer)
+                                <a title="ベストアンサーをつけます"
+                                    class="{{ $answer->status }} mt-2"
+                                    onclick="event.preventDefault(); document.getElementById('accept-answer-{{ $answer->id }}').submit();"
+                                    >
+                                    <i class="fas fa-check fa-2x"></i>
+                                </a>
+                                <form id="accept-answer-{{ $answer->id }}" action="{{ route('answers.accept', $answer->id) }}" method="POST" style="display:none;">
+                                    @csrf
+                                </form>
+                            @else
+                                @if ($answer->is_best)
+                                    <a title="ベストアンサーです"
+                                        class="{{ $answer->status }} mt-2"
+                                        >
+                                        <i class="fas fa-check fa-2x"></i>
+                                    </a>
+                                    <form id="accept-answer-{{ $answer->id }}" action="{{ route('answers.accept', $answer->id) }}" method="POST" style="display:none;">
+                                        @csrf
+                                    </form>
+                                @endif
+                            @endcan
                         </div>
                         <div class="media-body">
                             {!! $answer->body_html !!}

--- a/resources/views/answers/_index.blade.php
+++ b/resources/views/answers/_index.blade.php
@@ -18,9 +18,15 @@
                             <a title="よくない返答です" class="vote-down off">
                                 <i class="fas fa-caret-down fa-3x"></i>
                             </a>
-                            <a title="ベストアンサーをつけます" class="{{ $answer->status }} mt-2">
+                            <a title="ベストアンサーをつけます"
+                                class="{{ $answer->status }} mt-2"
+                                onclick="event.preventDefault(); document.getElementById('accept-answer-{{ $answer->id }}').submit();"
+                                >
                                 <i class="fas fa-check fa-2x"></i>
                             </a>
+                            <form id="accept-answer-{{ $answer->id }}" action="{{ route('answers.accept', $answer->id) }}" method="POST" style="display:none;">
+                                @csrf
+                            </form>
                         </div>
                         <div class="media-body">
                             {!! $answer->body_html !!}

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,3 +23,4 @@ Route::resource('questions', 'QuestionsController')->except('show');
 // Route::post('/questions/{question}/answers', 'AnswersController@store')->name('answers.store');
 Route::resource('questions.answers', 'AnswersController')->except(['index', 'create', 'show']);
 Route::get('/questions/{slug}', 'QuestionsController@show')->name('questions.show');
+Route::post('/answers/{answer}/accept', 'AcceptAnswerController')->name('answers.accept');


### PR DESCRIPTION
# What
ベストアンサーを正常に表示、操作できるようにする

# Why
・AcceptAnswerのシングルアクションコントローラを作成し、POSTのルーティングを記述した。
・Questionモデルに、best_answer_idを設置する際の処理を記述した。
・_index.blade.phpにベストアンサーボタンを押下した際、Questionモデルに記述したメソッド処理を行うよう記述。ここまでによりベストアンサーの投稿ができるようになった。
・AnswerPolicy.phpにて、acceptアクションのポリシーを記述。現行ユーザーIDが回答のある質問を書いたユーザーIDと一致する場合のみ認可
・_index.blade.phpに、@canを用いてポリシーを反映させ、一致しないユーザーはベストアンサーボタンが表示されなくした。また、既にベストアンサーの投稿がある場合、そのマークのみみられるようにした。(can, else, ifの組み合わせ)
